### PR TITLE
feat: add bash shell support

### DIFF
--- a/gwt.bash
+++ b/gwt.bash
@@ -1,0 +1,68 @@
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║  gwt - Git Worktree Manager for AI Coding Assistants                      ║
+# ║  https://github.com/slowestmonkey/gwt                                     ║
+# ║  Bash version                                                              ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+
+# Determine script location for loading modules (bash equivalent of ${0:A:h})
+GWT_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load modules
+source "$GWT_SCRIPT_DIR/lib/config.bash"
+source "$GWT_SCRIPT_DIR/lib/session.bash"
+source "$GWT_SCRIPT_DIR/lib/providers.bash"
+source "$GWT_SCRIPT_DIR/lib/git.bash"
+source "$GWT_SCRIPT_DIR/lib/help.bash"
+source "$GWT_SCRIPT_DIR/lib/commands.bash"
+source "$GWT_SCRIPT_DIR/lib/completions.bash"
+
+# Load config and custom providers
+_gwt_load_config 2>/dev/null
+[[ -n "$GWT_PROVIDER" ]] && GWT_PROVIDER_SET=1
+_gwt_load_custom_providers
+_gwt_validate_config || true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main Entry Point
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Remove any existing alias to avoid conflicts
+unalias gwt 2>/dev/null || true
+
+gwt() {
+  # Handle --debug first (can combine with other args)
+  if [[ "$1" == "--debug" ]]; then
+    export GWT_DEBUG=1
+    shift
+  fi
+
+  local cmd="${1:-}"
+  shift 2>/dev/null || true
+
+  case "$cmd" in
+    -h|--help)    _gwt_help; return 0 ;;
+    -v|--version) echo "gwt version $GWT_VERSION"; return 0 ;;
+    create)       _gwt_cmd_create "$@" ;;
+    list|ls)      _gwt_cmd_list "$@" ;;
+    switch)       _gwt_cmd_switch "$@" ;;
+    remove|rm)    _gwt_cmd_remove "$@" ;;
+    clean)        _gwt_cmd_clean "$@" ;;
+    config)       _gwt_cmd_config "$@" ;;
+    help)
+      case "$1" in
+        create)    _gwt_help_create ;;
+        list|ls)   _gwt_help_list ;;
+        switch)    _gwt_help_switch ;;
+        remove|rm) _gwt_help_remove ;;
+        clean)     _gwt_help_clean ;;
+        config)    _gwt_help_config ;;
+        "")        _gwt_help ;;
+        *)         echo "gwt: unknown command '$1'" >&2; return 1 ;;
+      esac
+      ;;
+    "") _gwt_help ;;
+    *)  echo "gwt: unknown command '$cmd'. Run 'gwt help'" >&2; return 1 ;;
+  esac
+}
+
+_gwt_register_completions

--- a/install.sh
+++ b/install.sh
@@ -2,21 +2,56 @@
 set -e
 
 GWT_DIR="$HOME/.gwt"
-ZSHRC="$HOME/.zshrc"
 
 echo "Installing gwt..."
-
-# Check for zsh
-if ! command -v zsh >/dev/null 2>&1; then
-  echo "Error: zsh is required but not installed."
-  exit 1
-fi
 
 # Check for git
 if ! command -v git >/dev/null 2>&1; then
   echo "Error: git is required but not installed."
   exit 1
 fi
+
+# Detect user's shell
+DETECTED_SHELL=$(basename "${SHELL:-/bin/bash}")
+
+case "$DETECTED_SHELL" in
+  zsh)
+    RC_FILE="$HOME/.zshrc"
+    GWT_LOADER="gwt.zsh"
+    SHELL_NAME="zsh"
+    ;;
+  bash)
+    RC_FILE="$HOME/.bashrc"
+    GWT_LOADER="gwt.bash"
+    SHELL_NAME="bash"
+    # Check bash version (need 4.2+ for declare -gA associative arrays)
+    if command -v bash >/dev/null 2>&1; then
+      BASH_MAJOR=$(bash -c 'echo ${BASH_VERSINFO[0]}')
+      BASH_MINOR=$(bash -c 'echo ${BASH_VERSINFO[1]}')
+      if [ "$BASH_MAJOR" -lt 4 ] || { [ "$BASH_MAJOR" -eq 4 ] && [ "$BASH_MINOR" -lt 2 ]; }; then
+        echo "Warning: gwt requires bash 4.2+ for full functionality."
+        echo "Your bash version: $(bash --version | head -1)"
+        echo ""
+        echo "On macOS, you can install a newer bash with:"
+        echo "  brew install bash"
+        echo "Then add /opt/homebrew/bin/bash to /etc/shells and run:"
+        echo "  chsh -s /opt/homebrew/bin/bash"
+        echo ""
+      fi
+    fi
+    ;;
+  *)
+    echo "Warning: Unsupported shell '$DETECTED_SHELL'"
+    echo "gwt supports: bash, zsh"
+    echo ""
+    echo "Defaulting to bash installation..."
+    RC_FILE="$HOME/.bashrc"
+    GWT_LOADER="gwt.bash"
+    SHELL_NAME="bash"
+    ;;
+esac
+
+echo "Detected shell: $SHELL_NAME"
 
 # Clone or update
 if [ -d "$GWT_DIR" ]; then
@@ -27,16 +62,29 @@ else
   git clone --quiet https://github.com/slowestmonkey/gwt.git "$GWT_DIR"
 fi
 
-# Add to .zshrc if not already present
-if ! grep -q 'source.*\.gwt/gwt\.zsh' "$ZSHRC" 2>/dev/null; then
-  echo "" >> "$ZSHRC"
-  echo "# gwt - Git Worktree Manager" >> "$ZSHRC"
-  echo "source \"\$HOME/.gwt/gwt.zsh\"" >> "$ZSHRC"
-  echo "Added to $ZSHRC"
+# Add to shell rc file if not already present
+SOURCE_LINE="source \"\$HOME/.gwt/$GWT_LOADER\""
+# Escape dot in .gwt for proper regex matching
+GREP_PATTERN="source.*\\\.gwt/gwt\.\(zsh\|bash\)"
+
+if ! grep -qE "$GREP_PATTERN" "$RC_FILE" 2>/dev/null; then
+  echo "" >> "$RC_FILE"
+  echo "# gwt - Git Worktree Manager" >> "$RC_FILE"
+  echo "$SOURCE_LINE" >> "$RC_FILE"
+  echo "Added to $RC_FILE"
 else
-  echo "Already in $ZSHRC"
+  # Check if using the correct loader for current shell
+  if grep -q "gwt.zsh" "$RC_FILE" 2>/dev/null && [ "$SHELL_NAME" = "bash" ]; then
+    echo "Note: $RC_FILE sources gwt.zsh but you're using bash."
+    echo "You may want to change it to: source \"\$HOME/.gwt/gwt.bash\""
+  elif grep -q "gwt.bash" "$RC_FILE" 2>/dev/null && [ "$SHELL_NAME" = "zsh" ]; then
+    echo "Note: $RC_FILE sources gwt.bash but you're using zsh."
+    echo "You may want to change it to: source \"\$HOME/.gwt/gwt.zsh\""
+  else
+    echo "Already in $RC_FILE"
+  fi
 fi
 
 echo ""
 echo "Done! Restart your shell or run:"
-echo "  source ~/.zshrc"
+echo "  source $RC_FILE"

--- a/lib/commands.bash
+++ b/lib/commands.bash
@@ -1,0 +1,428 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Public Commands (Bash version)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# gwt create - Create a new worktree and launch AI assistant
+# ═══════════════════════════════════════════════════════════════════════════════
+_gwt_cmd_create() {
+  [[ "$1" == "-h" || "$1" == "--help" ]] && { _gwt_help_create; return 0; }
+  _gwt_require_repo || return 1
+
+  # Parse arguments
+  local base="" name="" local_branch=false mode="default"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)      _gwt_help_create; return 0 ;;
+      -l|--local)     local_branch=true; shift ;;
+      -d|--dangerous) mode="dangerous"; shift ;;
+      -s|--safe)      mode="safe"; shift ;;
+      -b)
+        [[ -z "$2" ]] && { echo "gwt: -b requires a branch name" >&2; return 1; }
+        base="$2"; shift 2
+        ;;
+      -*)             echo "gwt: unknown option '$1'" >&2; return 1 ;;
+      *)              name="$1"; shift ;;
+    esac
+  done
+
+  [[ -z "$name" ]] && {
+    echo "gwt: missing branch name" >&2
+    echo "Usage: gwt create [-l | -b <branch>] [-s|-d] <name>" >&2
+    return 1
+  }
+
+  # Determine base branch
+  if $local_branch; then
+    base=$(_gwt_current_branch)
+    if [[ -z "$base" ]]; then
+      echo "gwt: cannot use -l/--local in detached HEAD state" >&2
+      echo "gwt: use -b <branch> to specify a base branch instead" >&2
+      return 1
+    fi
+  elif [[ -z "$base" ]]; then
+    base=$(_gwt_default_branch)
+  fi
+
+  _gwt_debug "Creating worktree '$name' from base '$base'"
+
+  # Check if already checked out
+  if git worktree list | grep -q "\[$name\]"; then
+    echo "gwt: branch '$name' already checked out in another worktree" >&2
+    return 1
+  fi
+
+  local wt_path
+  wt_path=$(_gwt_worktree_path "$name")
+  mkdir -p "$(dirname "$wt_path")"
+
+  # Reuse existing worktree
+  if [[ -d "$wt_path" ]]; then
+    echo "Worktree exists: $wt_path"
+    cd "$wt_path" || { echo "gwt: failed to enter worktree" >&2; return 1; }
+    _gwt_launch_provider "$mode"
+    return $?
+  fi
+
+  # Create worktree
+  echo "Creating: $wt_path (from $base)"
+  if git show-ref --verify --quiet "refs/heads/$name"; then
+    git worktree add "$wt_path" "$name"
+  else
+    git worktree add -b "$name" "$wt_path" "$base"
+  fi || { echo "gwt: failed to create worktree" >&2; return 1; }
+
+  cd "$wt_path" || { echo "gwt: failed to enter worktree" >&2; return 1; }
+
+  # Optional: install dependencies
+  [[ -f "package.json" ]] && {
+    echo -n "Found package.json. Install dependencies? [y/N]: "
+    read -r response
+    [[ "$response" =~ ^[Yy]$ ]] && npm install
+  }
+
+  # Optional: copy .env files
+  local main_repo
+  main_repo=$(_gwt_main_repo)
+  local env_files=()
+  # Bash equivalent of ${(@f)$(find ...)}
+  while IFS= read -r -d '' f; do
+    env_files+=("$f")
+  done < <(find "$main_repo" -maxdepth 3 -name ".env*" -type f -print0 2>/dev/null)
+
+  if [[ ${#env_files[@]} -gt 0 && -n "${env_files[0]}" ]]; then
+    echo -n "Found ${#env_files[@]} .env file(s). Copy? [y/N]: "
+    read -r response
+    [[ "$response" =~ ^[Yy]$ ]] && {
+      for env_file in "${env_files[@]}"; do
+        local rel_path="${env_file#$main_repo/}"
+        local target_dir
+        target_dir="$(dirname "$rel_path")"
+        [[ "$target_dir" != "." ]] && mkdir -p "$target_dir"
+        cp "$env_file" "$rel_path"
+      done
+      echo "Copied ${#env_files[@]} .env file(s)"
+    }
+  fi
+
+  _gwt_launch_provider "$mode"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# gwt list - List all worktrees with status
+# ═══════════════════════════════════════════════════════════════════════════════
+_gwt_cmd_list() {
+  [[ "$1" == "-h" || "$1" == "--help" ]] && { _gwt_help_list; return 0; }
+  _gwt_require_repo || return 1
+
+  _gwt_session_cleanup
+
+  local cwd
+  cwd=$(_gwt_realpath "$(pwd)")
+  echo -e "\033[1mGit Worktrees:\033[0m\n"
+
+  local wt_path="" wt_branch="" head_line="" branch_line=""
+  while IFS= read -r line; do
+    if [[ "$line" == worktree* ]]; then
+      wt_path="${line#worktree }"
+      read -r head_line
+      read -r branch_line
+      if [[ "$branch_line" == branch* ]]; then
+        wt_branch="${branch_line#branch refs/heads/}"
+      else
+        wt_branch="(detached)"
+      fi
+
+      local indicator="" status_text="" session_indicator=""
+      local resolved_wt
+      resolved_wt=$(_gwt_realpath "$wt_path")
+      [[ "$cwd" == "$resolved_wt"* ]] && indicator="→ "
+
+      _gwt_session_active "$wt_path" && session_indicator=$' \033[35m⚡\033[0m'
+
+      if [[ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]]; then
+        status_text=$'\033[33m●\033[0m dirty'
+      else
+        status_text=$'\033[32m●\033[0m clean'
+      fi
+
+      if git -C "$wt_path" rev-parse --abbrev-ref '@{upstream}' &>/dev/null; then
+        local ahead behind
+        ahead=$(git -C "$wt_path" rev-list --count '@{upstream}..HEAD' 2>/dev/null)
+        behind=$(git -C "$wt_path" rev-list --count 'HEAD..@{upstream}' 2>/dev/null)
+        [[ "$ahead" -gt 0 ]] && status_text="$status_text ↑$ahead"
+        [[ "$behind" -gt 0 ]] && status_text="$status_text ↓$behind"
+      fi
+
+      if [[ -n "$indicator" ]]; then
+        echo -e "  \033[32m$indicator$wt_branch\033[0m$session_indicator  $status_text"
+      else
+        echo -e "  \033[34m$wt_branch\033[0m$session_indicator  $status_text"
+      fi
+      echo -e "    $wt_path\n"
+    fi
+  done <<< "$(git worktree list --porcelain)"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# gwt switch - Switch to existing worktree (optionally launch AI)
+# ═══════════════════════════════════════════════════════════════════════════════
+_gwt_cmd_switch() {
+  [[ "$1" == "-h" || "$1" == "--help" ]] && { _gwt_help_switch; return 0; }
+  _gwt_require_repo || return 1
+
+  local wt_branch="" mode="default" no_ai=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)      _gwt_help_switch; return 0 ;;
+      -n|--no-ai)     no_ai=true; shift ;;
+      -d|--dangerous) mode="dangerous"; shift ;;
+      -s|--safe)      mode="safe"; shift ;;
+      -*)             echo "gwt: unknown option '$1'" >&2; return 1 ;;
+      *)              wt_branch="$1"; shift ;;
+    esac
+  done
+
+  [[ -z "$wt_branch" ]] && {
+    echo "gwt: missing branch name" >&2
+    echo ""
+    _gwt_cmd_list
+    return 1
+  }
+
+  local wt_path
+  wt_path=$(_gwt_find_path "$wt_branch") || return 1
+  cd "$wt_path" || { echo "gwt: failed to enter worktree at $wt_path" >&2; return 1; }
+  echo "Switched to: $wt_path"
+
+  $no_ai || _gwt_launch_provider "$mode"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# gwt clean - Remove all clean worktrees
+# ═══════════════════════════════════════════════════════════════════════════════
+_gwt_cmd_clean() {
+  [[ "$1" == "-h" || "$1" == "--help" ]] && { _gwt_help_clean; return 0; }
+  _gwt_require_repo || return 1
+
+  local force=false
+  [[ "$1" == "-f" || "$1" == "--force" ]] && force=true
+
+  local main_repo
+  main_repo=$(_gwt_main_repo)
+  local cwd
+  cwd=$(_gwt_realpath "$(pwd)")
+  local to_remove=()
+  local wt_path="" wt_branch=""
+
+  while IFS= read -r line; do
+    if [[ "$line" == worktree* ]]; then
+      wt_path="${line#worktree }"
+      read -r _
+      read -r branch_line
+      if [[ "$branch_line" == branch* ]]; then
+        wt_branch="${branch_line#branch refs/heads/}"
+      else
+        wt_branch=""
+      fi
+
+      [[ "$wt_path" == "$main_repo" ]] && continue
+      [[ "$(_gwt_realpath "$wt_path")" == "$cwd"* ]] && continue
+      [[ -n "$wt_branch" ]] && _gwt_is_protected "$wt_branch" && continue
+
+      if [[ -z "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]]; then
+        to_remove+=("$wt_path:$wt_branch")
+      fi
+    fi
+  done <<< "$(git worktree list --porcelain)"
+
+  if [[ ${#to_remove[@]} -eq 0 ]]; then
+    echo "No clean worktrees to remove"
+    return 0
+  fi
+
+  echo "Clean worktrees to remove:"
+  for item in "${to_remove[@]}"; do
+    echo "  - ${item#*:} (${item%%:*})"
+  done
+  echo ""
+
+  if ! $force; then
+    echo -n "Remove all ${#to_remove[@]} worktrees? [y/N]: "
+    read -r response
+    [[ ! "$response" =~ ^[Yy]$ ]] && { echo "Cancelled"; return 0; }
+  fi
+
+  local removed=0
+  for item in "${to_remove[@]}"; do
+    local wt_rm_path="${item%%:*}"
+    local wt_rm_branch="${item#*:}"
+
+    if git worktree remove --force "$wt_rm_path" 2>/dev/null; then
+      echo "Removed: $wt_rm_path"
+      ((removed++))
+      if [[ -n "$wt_rm_branch" ]] && ! _gwt_is_protected "$wt_rm_branch"; then
+        git branch -D "$wt_rm_branch" 2>/dev/null && echo "Deleted branch: $wt_rm_branch"
+      fi
+    fi
+  done
+
+  git worktree prune
+  echo -e "\nRemoved $removed worktree(s)"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# gwt remove - Remove worktree and branch
+# ═══════════════════════════════════════════════════════════════════════════════
+_gwt_cmd_remove() {
+  [[ "$1" == "-h" || "$1" == "--help" ]] && { _gwt_help_remove; return 0; }
+  _gwt_require_repo || return 1
+
+  local force=false keep_branch=false wt_branch=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)        _gwt_help_remove; return 0 ;;
+      -f|--force)       force=true; shift ;;
+      -k|--keep-branch) keep_branch=true; shift ;;
+      -*)               echo "gwt: unknown option '$1'" >&2; return 1 ;;
+      *)                wt_branch="$1"; shift ;;
+    esac
+  done
+
+  [[ -z "$wt_branch" ]] && {
+    echo "gwt: missing branch name" >&2
+    _gwt_cmd_list
+    return 1
+  }
+
+  _gwt_is_protected "$wt_branch" && {
+    echo "gwt: cannot remove protected branch '$wt_branch'" >&2
+    return 1
+  }
+
+  local wt_path
+  wt_path=$(_gwt_find_path "$wt_branch") || return 1
+  local main
+  main=$(_gwt_main_repo)
+  local cwd
+  cwd=$(_gwt_realpath "$(pwd)")
+  local resolved_wt
+  resolved_wt=$(_gwt_realpath "$wt_path")
+
+  [[ "$resolved_wt" == "$(_gwt_realpath "$main")" ]] && {
+    echo "gwt: cannot remove main repository" >&2
+    return 1
+  }
+
+  [[ "$cwd" == "$resolved_wt"* ]] && {
+    echo "gwt: cannot remove current worktree. Switch first." >&2
+    return 1
+  }
+
+  local branch_to_delete=""
+  while IFS= read -r line; do
+    [[ "$line" == worktree* ]] && local wt="${line#worktree }"
+    [[ "$line" == branch* ]] && {
+      local br="${line#branch refs/heads/}"
+      [[ "$wt" == "$wt_path" ]] && branch_to_delete="$br"
+    }
+  done <<< "$(git worktree list --porcelain)"
+
+  if [[ -n $(git -C "$wt_path" status --porcelain 2>/dev/null) ]] && ! $force; then
+    echo "gwt: worktree has uncommitted changes. Use -f to force." >&2
+    return 1
+  fi
+
+  if ! $force; then
+    echo -n "Remove $wt_path? [y/N]: "
+    read -r response
+    [[ ! "$response" =~ ^[Yy]$ ]] && { echo "Cancelled"; return 0; }
+  fi
+
+  git worktree remove --force "$wt_path" || {
+    echo "gwt: failed to remove worktree" >&2
+    return 1
+  }
+  echo "Removed: $wt_path"
+  git worktree prune
+
+  if ! $keep_branch && [[ -n "$branch_to_delete" ]] && ! _gwt_is_protected "$branch_to_delete"; then
+    git branch -D "$branch_to_delete" 2>/dev/null && echo "Deleted local branch: $branch_to_delete"
+
+    git fetch --prune origin 2>/dev/null
+    if git show-ref --verify --quiet "refs/remotes/origin/$branch_to_delete"; then
+      echo -n "Delete remote 'origin/$branch_to_delete'? [y/N]: "
+      read -r response
+      [[ "$response" =~ ^[Yy]$ ]] && \
+        git push origin --delete "$branch_to_delete" 2>/dev/null && \
+        echo "Deleted remote branch"
+    fi
+  fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# gwt config - Show/edit configuration and manage providers
+# ═══════════════════════════════════════════════════════════════════════════════
+_gwt_cmd_config() {
+  [[ "$1" == "-h" || "$1" == "--help" ]] && { _gwt_help_config; return 0; }
+
+  case "$1" in
+    "")
+      _gwt_show_config
+      echo ""
+      _gwt_list_providers
+      ;;
+    provider|providers)
+      if [[ -n "$2" ]]; then
+        # Set provider
+        local provider="$2"
+        local info="${GWT_PROVIDERS[$provider]:-}"
+
+        if [[ -z "$info" ]]; then
+          echo "gwt: unknown provider '$provider'" >&2
+          echo "Available: ${!GWT_PROVIDERS[*]}" >&2
+          return 1
+        fi
+
+        local cmd="${info%%|*}"
+        local name="${info##*|}"
+
+        if ! command -v "$cmd" &>/dev/null; then
+          echo "gwt: '$cmd' not found. Install $name first." >&2
+          return 1
+        fi
+
+        _gwt_save_config "GWT_PROVIDER" "$provider"
+        export GWT_PROVIDER="$provider"
+        echo "Provider set to: $name ($provider)"
+      else
+        # Interactive selection
+        echo -e "\033[1mCurrent provider:\033[0m $GWT_PROVIDER\n"
+        _gwt_list_providers
+        echo ""
+        echo -n "Select new provider? [y/N]: "
+        read -r choice
+        [[ "$choice" =~ ^[Yy]$ ]] && _gwt_select_provider
+      fi
+      ;;
+    edit)
+      local config_file="$HOME/.config/gwt/config"
+      mkdir -p "$(dirname "$config_file")"
+      [[ ! -f "$config_file" ]] && touch "$config_file"
+      ${EDITOR:-vim} "$config_file"
+      ;;
+    set)
+      [[ -z "$2" || -z "$3" ]] && {
+        echo "Usage: gwt config set <key> <value>" >&2
+        return 1
+      }
+      _gwt_save_config "$2" "$3"
+      echo "Set $2=$3"
+      ;;
+    *)
+      echo "gwt: unknown config command '$1'" >&2
+      echo "Usage: gwt config [provider [name] | edit | set <key> <value>]" >&2
+      return 1
+      ;;
+  esac
+}

--- a/lib/completions.bash
+++ b/lib/completions.bash
@@ -1,0 +1,137 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Bash Completions
+# Note: Works best with bash-completion package installed (provides _init_completion)
+# On macOS: brew install bash-completion@2
+# On Linux: usually pre-installed, or: apt install bash-completion
+# ─────────────────────────────────────────────────────────────────────────────
+
+_gwt_complete_branches() {
+  local branches=()
+  while IFS= read -r line; do
+    [[ "$line" == branch* ]] && branches+=("${line#branch refs/heads/}")
+  done <<< "$(git worktree list --porcelain 2>/dev/null)"
+  echo "${branches[*]}"
+}
+
+_gwt_complete_git_branches() {
+  git branch -a --format='%(refname:short)' 2>/dev/null
+}
+
+_gwt_complete_providers() {
+  echo "${!GWT_PROVIDERS[*]}"
+}
+
+_gwt_completions() {
+  local cur prev words cword
+  _init_completion 2>/dev/null || {
+    # Fallback if _init_completion not available
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    words=("${COMP_WORDS[@]}")
+    cword=$COMP_CWORD
+  }
+
+  local commands="create list ls switch remove rm clean config help"
+  local create_opts="-h --help -l --local -d --dangerous -s --safe -b"
+  local switch_opts="-h --help -n --no-ai -d --dangerous -s --safe"
+  local remove_opts="-h --help -f --force -k --keep-branch"
+  local clean_opts="-h --help -f --force"
+  local config_subcmds="provider edit set"
+  local help_topics="create list switch remove clean config"
+
+  # Handle first argument (command)
+  if [[ $cword -eq 1 ]]; then
+    COMPREPLY=($(compgen -W "$commands -h --help -v --version --debug" -- "$cur"))
+    return
+  fi
+
+  # Handle --debug as first arg
+  if [[ "${words[1]}" == "--debug" ]]; then
+    if [[ $cword -eq 2 ]]; then
+      COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+      return
+    fi
+    # Shift effective command position
+    local cmd="${words[2]}"
+    local effective_cword=$((cword - 1))
+  else
+    local cmd="${words[1]}"
+    local effective_cword=$cword
+  fi
+
+  case "$cmd" in
+    create)
+      case "$prev" in
+        -b)
+          local branches
+          branches=$(_gwt_complete_git_branches)
+          COMPREPLY=($(compgen -W "$branches" -- "$cur"))
+          ;;
+        *)
+          if [[ "$cur" == -* ]]; then
+            COMPREPLY=($(compgen -W "$create_opts" -- "$cur"))
+          fi
+          ;;
+      esac
+      ;;
+
+    switch)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "$switch_opts" -- "$cur"))
+      else
+        local branches
+        branches=$(_gwt_complete_branches)
+        COMPREPLY=($(compgen -W "$branches" -- "$cur"))
+      fi
+      ;;
+
+    remove|rm)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "$remove_opts" -- "$cur"))
+      else
+        local branches
+        branches=$(_gwt_complete_branches)
+        COMPREPLY=($(compgen -W "$branches" -- "$cur"))
+      fi
+      ;;
+
+    clean)
+      COMPREPLY=($(compgen -W "$clean_opts" -- "$cur"))
+      ;;
+
+    config)
+      case "$effective_cword" in
+        2)
+          COMPREPLY=($(compgen -W "$config_subcmds" -- "$cur"))
+          ;;
+        3)
+          case "$prev" in
+            provider)
+              local providers
+              providers=$(_gwt_complete_providers)
+              COMPREPLY=($(compgen -W "$providers" -- "$cur"))
+              ;;
+            set)
+              COMPREPLY=($(compgen -W "GWT_PROVIDER GWT_DEBUG" -- "$cur"))
+              ;;
+          esac
+          ;;
+      esac
+      ;;
+
+    help)
+      COMPREPLY=($(compgen -W "$help_topics" -- "$cur"))
+      ;;
+
+    list|ls)
+      COMPREPLY=($(compgen -W "-h --help" -- "$cur"))
+      ;;
+  esac
+}
+
+_gwt_register_completions() {
+  # Only register if running in bash
+  if [[ -n "$BASH_VERSION" ]]; then
+    complete -F _gwt_completions gwt
+  fi
+}

--- a/lib/config.bash
+++ b/lib/config.bash
@@ -1,0 +1,113 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Configuration Management (Bash version)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Version
+GWT_VERSION="2.0.0"
+
+# Config file locations (in order of priority)
+GWT_CONFIG_PATHS=(
+  "./.gwt.conf"
+  "$HOME/.config/gwt/config"
+  "$HOME/.gwt.conf"
+)
+
+# Session tracking directory
+GWT_SESSION_DIR="$HOME/.gwt-worktrees/.sessions"
+
+# Debug mode (set GWT_DEBUG=1 to enable)
+: "${GWT_DEBUG:=0}"
+
+# Default provider (can be overridden via config or GWT_PROVIDER env var)
+: "${GWT_PROVIDER:=claude}"
+
+# Debug logging
+_gwt_debug() {
+  [[ "$GWT_DEBUG" == "1" ]] && echo "[gwt:debug] $*" >&2
+}
+
+# Load user config if exists
+_gwt_load_config() {
+  local config_file
+  for config_file in "${GWT_CONFIG_PATHS[@]}"; do
+    if [[ -f "$config_file" ]]; then
+      _gwt_debug "Loading config from: $config_file"
+      source "$config_file"
+      return 0
+    fi
+  done
+  _gwt_debug "No config file found"
+  return 1
+}
+
+# Check if provider was explicitly configured
+_gwt_provider_configured() {
+  # Check if config file exists and contains GWT_PROVIDER
+  local config_file
+  for config_file in "${GWT_CONFIG_PATHS[@]}"; do
+    if [[ -f "$config_file" ]] && grep -q "^GWT_PROVIDER=" "$config_file" 2>/dev/null; then
+      return 0
+    fi
+  done
+  # Check if env var was set before sourcing
+  [[ -n "${GWT_PROVIDER_SET:-}" ]] && return 0
+  return 1
+}
+
+# Validate configuration
+_gwt_validate_config() {
+  if [[ -n "$GWT_PROVIDER" ]] && [[ -z "${GWT_PROVIDERS[$GWT_PROVIDER]:-}" ]]; then
+    echo "gwt: unknown provider '$GWT_PROVIDER' in config" >&2
+    echo "gwt: available providers: ${!GWT_PROVIDERS[*]}" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Save config value
+_gwt_save_config() {
+  local key="$1" value="$2"
+  local config_file="$HOME/.config/gwt/config"
+
+  mkdir -p "$(dirname "$config_file")"
+
+  if [[ -f "$config_file" ]]; then
+    # Update existing key or append
+    if grep -q "^${key}=" "$config_file" 2>/dev/null; then
+      # Use temp file for portability
+      local tmp
+      tmp=$(mktemp)
+      sed "s/^${key}=.*/${key}=${value}/" "$config_file" > "$tmp"
+      mv "$tmp" "$config_file"
+    else
+      echo "${key}=${value}" >> "$config_file"
+    fi
+  else
+    echo "${key}=${value}" > "$config_file"
+  fi
+  _gwt_debug "Saved $key=$value to $config_file"
+}
+
+# Show current config
+_gwt_show_config() {
+  echo -e "\033[1mGWT Configuration\033[0m\n"
+
+  # Show active config file
+  local config_file found=false
+  for config_file in "${GWT_CONFIG_PATHS[@]}"; do
+    if [[ -f "$config_file" ]]; then
+      echo -e "Config file: \033[32m$config_file\033[0m"
+      found=true
+      break
+    fi
+  done
+  $found || echo -e "Config file: \033[33m(none)\033[0m"
+
+  echo ""
+  echo "Settings:"
+  echo "  GWT_PROVIDER=$GWT_PROVIDER"
+  echo "  GWT_DEBUG=$GWT_DEBUG"
+  echo ""
+  echo "Storage: $HOME/.gwt-worktrees/"
+  echo "Sessions: $GWT_SESSION_DIR"
+}

--- a/lib/git.bash
+++ b/lib/git.bash
@@ -1,0 +1,154 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Git Helper Functions (Bash version)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Check if inside a git repo
+_gwt_require_repo() {
+  if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "gwt: not inside a git repository" >&2
+    echo "gwt: run this command from within a git project" >&2
+    return 1
+  fi
+}
+
+# Get main repository path (bare repo or primary checkout)
+_gwt_main_repo() {
+  git worktree list --porcelain | head -1 | sed 's/^worktree //'
+}
+
+# Get default branch (from origin/HEAD or fallback to "main")
+_gwt_default_branch() {
+  git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main"
+}
+
+# Sanitize branch name for filesystem use
+_gwt_sanitize_branch_name() {
+  local name="$1"
+  # Replace problematic characters with dashes
+  # Handles: / : * ? " < > | \ space
+  echo "${name//[\/\:\*\?\"\<\>\|\\ ]/-}"
+}
+
+# Generate unique worktree path (handles repo name collisions)
+_gwt_worktree_path() {
+  local branch_name="$1"
+  local repo_path
+  repo_path=$(_gwt_main_repo)
+  local repo_name
+  repo_name=$(basename "$repo_path")
+
+  # Create short hash of repo path to avoid collisions
+  local repo_hash
+  if command -v md5 &>/dev/null; then
+    repo_hash=$(echo "$repo_path" | md5 | cut -c1-8)
+  elif command -v md5sum &>/dev/null; then
+    repo_hash=$(echo "$repo_path" | md5sum | cut -c1-8)
+  else
+    # Fallback: use last 8 chars of path hash via cksum
+    repo_hash=$(echo "$repo_path" | cksum | cut -d' ' -f1)
+  fi
+
+  local safe_branch
+  safe_branch=$(_gwt_sanitize_branch_name "$branch_name")
+  echo "$HOME/.gwt-worktrees/${repo_name}-${repo_hash}/${safe_branch}"
+}
+
+# Resolve path safely (handles symlinks)
+_gwt_realpath() {
+  local path="$1"
+  if command -v realpath &>/dev/null; then
+    realpath "$path" 2>/dev/null || echo "$path"
+  elif command -v grealpath &>/dev/null; then
+    grealpath "$path" 2>/dev/null || echo "$path"
+  else
+    # Fallback for macOS without coreutils
+    cd "$path" 2>/dev/null && pwd -P || echo "$path"
+  fi
+}
+
+# Find worktree path by branch name (exact or partial match)
+_gwt_find_path() {
+  local search="$1"
+  local exact="" partial=()
+  local wt_path="" wt_branch=""
+
+  while IFS= read -r line; do
+    [[ "$line" == worktree* ]] && wt_path="${line#worktree }"
+    [[ "$line" == branch* ]] && {
+      wt_branch="${line#branch refs/heads/}"
+      [[ "$wt_branch" == "$search" ]] && exact="$wt_path"
+      [[ "$wt_branch" == *"$search"* && -z "$exact" ]] && partial+=("$wt_path:$wt_branch")
+    }
+  done <<< "$(git worktree list --porcelain)"
+
+  if [[ -n "$exact" ]]; then
+    echo "$exact"
+    return 0
+  fi
+
+  case ${#partial[@]} in
+    0)
+      echo "gwt: no worktree matches '$search'" >&2
+      echo "gwt: use 'gwt list' to see available worktrees" >&2
+      return 1
+      ;;
+    1)
+      # Bash arrays are 0-indexed
+      echo "${partial[0]%%:*}"
+      ;;
+    *)
+      echo "gwt: multiple worktrees match '$search':" >&2
+      for p in "${partial[@]}"; do
+        echo "  - ${p#*:}" >&2
+      done
+      echo "gwt: please be more specific" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Check if branch is protected (main/master/default)
+_gwt_is_protected() {
+  local branch="$1"
+  local default
+  default=$(_gwt_default_branch)
+  [[ "$branch" == "$default" || "$branch" == "main" || "$branch" == "master" ]]
+}
+
+# Get current branch (with detached HEAD handling)
+_gwt_current_branch() {
+  local branch
+  branch=$(git branch --show-current 2>/dev/null)
+  if [[ -z "$branch" ]]; then
+    echo ""
+    return 1
+  fi
+  echo "$branch"
+}
+
+# Check if in detached HEAD state
+_gwt_is_detached() {
+  [[ -z "$(git branch --show-current 2>/dev/null)" ]]
+}
+
+# Get worktree info for a path
+_gwt_worktree_info() {
+  local search_path="$1"
+  search_path=$(_gwt_realpath "$search_path")
+
+  local wt_path="" wt_branch="" wt_head=""
+  while IFS= read -r line; do
+    case "$line" in
+      worktree*) wt_path="${line#worktree }" ;;
+      HEAD*) wt_head="${line#HEAD }" ;;
+      branch*)
+        wt_branch="${line#branch refs/heads/}"
+        if [[ "$(_gwt_realpath "$wt_path")" == "$search_path" ]]; then
+          echo "$wt_branch|$wt_head|$wt_path"
+          return 0
+        fi
+        ;;
+    esac
+  done <<< "$(git worktree list --porcelain)"
+  return 1
+}

--- a/lib/help.bash
+++ b/lib/help.bash
@@ -1,0 +1,160 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Help System (Bash version)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_gwt_help() {
+  cat <<EOF
+gwt - Git Worktree Manager for AI Coding Assistants (v$GWT_VERSION)
+
+USAGE
+  gwt <command> [options] [arguments]
+
+COMMANDS
+  create    Create worktree and launch AI assistant
+  list      List worktrees with status (alias: ls)
+  switch    Switch to worktree and launch AI (-n to skip AI)
+  remove    Remove worktree and branch (alias: rm)
+  clean     Remove all clean worktrees
+  config    Show/edit config, manage providers
+  help      Show help for a command
+
+OPTIONS
+  -h, --help     Show help
+  -v, --version  Show version
+  --debug        Enable debug output
+
+EXAMPLES
+  gwt create feature-login     Create from default branch
+  gwt create -l fix-bug        Create from current branch
+  gwt switch feature-login     Switch + launch AI
+  gwt switch -n feature-login  Switch only (no AI)
+  gwt remove feature-login     Remove worktree + branch
+  gwt config provider opencode Set provider
+
+PERMISSION MODES
+  -s, --safe       Restricted tools (provider-dependent)
+  -d, --dangerous  Skip all permission prompts
+EOF
+}
+
+_gwt_help_create() {
+  cat <<EOF
+gwt create - Create worktree and launch AI assistant
+
+USAGE
+  gwt create [options] <branch-name>
+
+OPTIONS
+  -l, --local      Use current branch as base
+  -b <branch>      Use specific branch as base
+  -s, --safe       Launch in safe mode
+  -d, --dangerous  Launch in dangerous mode
+  -h, --help       Show this help
+
+EXAMPLES
+  gwt create feature-auth
+  gwt create -l hotfix-123
+  gwt create -b develop new-feat
+  gwt create -d feature-quick
+EOF
+}
+
+_gwt_help_list() {
+  cat <<EOF
+gwt list - List all worktrees with status
+
+USAGE
+  gwt list
+  gwt ls
+
+STATUS INDICATORS
+  →   Current worktree
+  ●   green=clean, yellow=dirty
+  ↑n  Commits ahead of remote
+  ↓n  Commits behind remote
+  ⚡  Active AI session
+EOF
+}
+
+_gwt_help_switch() {
+  cat <<EOF
+gwt switch - Switch to worktree and optionally launch AI
+
+USAGE
+  gwt switch [options] <branch-name>
+
+OPTIONS
+  -n, --no-ai      Just cd, don't launch AI
+  -s, --safe       Launch in safe mode
+  -d, --dangerous  Launch in dangerous mode
+  -h, --help       Show this help
+
+EXAMPLES
+  gwt switch feature-auth      Switch + launch AI
+  gwt switch -n feature-auth   Just cd
+  gwt switch feat              Partial match
+EOF
+}
+
+_gwt_help_clean() {
+  cat <<EOF
+gwt clean - Remove all clean worktrees
+
+USAGE
+  gwt clean [-f]
+
+OPTIONS
+  -f, --force  Skip confirmation
+  -h, --help   Show this help
+
+NOTES
+  - Only removes worktrees with no uncommitted changes
+  - Skips main repo, current dir, protected branches
+  - Also deletes associated branches
+EOF
+}
+
+_gwt_help_remove() {
+  cat <<EOF
+gwt remove - Remove worktree and optionally delete branch
+
+USAGE
+  gwt remove [options] <branch-name>
+  gwt rm [options] <branch-name>
+
+OPTIONS
+  -f, --force        Force remove dirty worktree
+  -k, --keep-branch  Keep the branch
+  -h, --help         Show this help
+
+EXAMPLES
+  gwt rm feature-done       Remove + delete branch
+  gwt rm -k feature-wip     Keep branch
+  gwt rm -f feature-old     Force remove
+EOF
+}
+
+_gwt_help_config() {
+  cat <<EOF
+gwt config - Show/edit configuration and manage providers
+
+USAGE
+  gwt config                    Show config + providers
+  gwt config provider           Interactive provider selection
+  gwt config provider <name>    Set provider directly
+  gwt config edit               Edit config in \$EDITOR
+  gwt config set <key> <value>  Set config value
+
+PROVIDERS
+  claude, opencode, aider, cursor
+
+CONFIG FILES (priority order)
+  ./.gwt.conf
+  ~/.config/gwt/config
+  ~/.gwt.conf
+
+CUSTOM PROVIDERS
+  Add to ~/.config/gwt/providers.d/myai.bash:
+    GWT_PROVIDERS[myai]="myai-cli|||My AI"
+EOF
+}

--- a/lib/providers.bash
+++ b/lib/providers.bash
@@ -1,0 +1,262 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Provider Registry & Management (Bash version)
+# Requires: Bash 4.2+ (for declare -gA associative arrays)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Provider registry: command|safe_flags|dangerous_flags|display_name
+declare -gA GWT_PROVIDERS
+GWT_PROVIDERS=(
+  [claude]="claude|--allowedTools|--dangerously-skip-permissions|Claude Code"
+  [opencode]="opencode|||OpenCode"
+  [aider]="aider|||Aider"
+  [cursor]="cursor|||Cursor"
+)
+
+# Claude-specific allowed tools for safe mode
+GWT_ALLOWED_TOOLS=(
+  "Read" "Edit" "Write" "Grep" "Glob"
+  "Bash(git:*)" "Bash(npm:*)" "Bash(ls:*)" "Bash(cat:*)"
+)
+
+# Load custom providers from providers.d/
+_gwt_load_custom_providers() {
+  local provider_dir="${GWT_SCRIPT_DIR}/providers.d"
+  if [[ -d "$provider_dir" ]]; then
+    # Bash nullglob handling
+    local old_nullglob
+    old_nullglob=$(shopt -p nullglob 2>/dev/null || echo "shopt -u nullglob")
+    shopt -s nullglob
+    # Support .bash, .sh, and .zsh (for backwards compatibility with zsh configs)
+    for f in "$provider_dir"/*.bash "$provider_dir"/*.sh "$provider_dir"/*.zsh; do
+      _gwt_debug "Loading custom provider: $f"
+      source "$f"
+    done
+    eval "$old_nullglob"
+  fi
+
+  # Also load from user config dir
+  local user_provider_dir="$HOME/.config/gwt/providers.d"
+  if [[ -d "$user_provider_dir" ]]; then
+    local old_nullglob
+    old_nullglob=$(shopt -p nullglob 2>/dev/null || echo "shopt -u nullglob")
+    shopt -s nullglob
+    # Support .bash, .sh, and .zsh (for backwards compatibility with zsh configs)
+    for f in "$user_provider_dir"/*.bash "$user_provider_dir"/*.sh "$user_provider_dir"/*.zsh; do
+      _gwt_debug "Loading user provider: $f"
+      source "$f"
+    done
+    eval "$old_nullglob"
+  fi
+}
+
+# Get provider info: returns "command|safe_flags|dangerous_flags|display_name"
+_gwt_get_provider() {
+  local provider="${1:-$GWT_PROVIDER}"
+  echo "${GWT_PROVIDERS[$provider]:-}"
+}
+
+# Check if provider is available (command exists)
+_gwt_provider_available() {
+  local provider="${1:-$GWT_PROVIDER}"
+  local info
+  info=$(_gwt_get_provider "$provider")
+  [[ -z "$info" ]] && return 1
+  local cmd="${info%%|*}"
+  command -v "$cmd" &>/dev/null
+}
+
+# List available providers
+_gwt_list_providers() {
+  echo "Available providers:"
+  local provider info cmd name available
+  for provider in "${!GWT_PROVIDERS[@]}"; do
+    info="${GWT_PROVIDERS[$provider]}"
+    cmd="${info%%|*}"
+    name="${info##*|}"
+    if command -v "$cmd" &>/dev/null; then
+      available=$'\033[32m✓\033[0m'
+    else
+      available=$'\033[31m✗\033[0m'
+    fi
+    [[ "$provider" == "$GWT_PROVIDER" ]] && name="$name"$' \033[33m(active)\033[0m'
+    echo -e "  $available $provider - $name"
+  done
+}
+
+# Interactive provider selection (with recursion guard)
+_gwt_select_provider() {
+  local _gwt_select_depth=${_gwt_select_depth:-0}
+
+  if (( _gwt_select_depth > 3 )); then
+    echo "gwt: too many provider selection attempts" >&2
+    return 1
+  fi
+
+  local available=() provider info cmd name
+
+  # Build list of available (installed) providers (in preferred order)
+  for provider in claude opencode aider cursor; do
+    info="${GWT_PROVIDERS[$provider]:-}"
+    [[ -z "$info" ]] && continue
+    cmd="${info%%|*}"
+    name="${info##*|}"
+    command -v "$cmd" &>/dev/null && available+=("$provider:$name")
+  done
+
+  # Also check custom providers
+  for provider in "${!GWT_PROVIDERS[@]}"; do
+    [[ "$provider" =~ ^(claude|opencode|aider|cursor)$ ]] && continue
+    info="${GWT_PROVIDERS[$provider]}"
+    cmd="${info%%|*}"
+    name="${info##*|}"
+    command -v "$cmd" &>/dev/null && available+=("$provider:$name")
+  done
+
+  [[ ${#available[@]} -eq 0 ]] && {
+    echo "gwt: no AI coding assistants found" >&2
+    echo "gwt: install one of: claude, opencode, aider, cursor" >&2
+    return 1
+  }
+
+  # If only one available, use it
+  [[ ${#available[@]} -eq 1 ]] && {
+    GWT_PROVIDER="${available[0]%%:*}"
+    echo "Auto-selected provider: ${available[0]#*:} (only one installed)"
+    return 0
+  }
+
+  # Interactive selection
+  echo -e "\033[1mSelect your AI coding assistant:\033[0m\n"
+  local i=1
+  for item in "${available[@]}"; do
+    local p="${item%%:*}"
+    local n="${item#*:}"
+    echo "  $i) $n ($p)"
+    ((i++))
+  done
+  echo ""
+
+  local choice
+  while true; do
+    echo -n "Enter choice [1-${#available[@]}]: "
+    read -r choice
+    [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= ${#available[@]} )) && break
+    echo "Invalid choice. Try again."
+  done
+
+  # Bash arrays are 0-indexed, so subtract 1
+  local idx=$((choice - 1))
+  GWT_PROVIDER="${available[$idx]%%:*}"
+  local selected_name="${available[$idx]#*:}"
+  echo ""
+  echo "Selected: $selected_name"
+
+  # Offer to save
+  echo -n "Save to config (~/.config/gwt/config)? [Y/n]: "
+  read -r save_choice
+  [[ ! "$save_choice" =~ ^[Nn]$ ]] && {
+    _gwt_save_config "GWT_PROVIDER" "$GWT_PROVIDER"
+    echo "Saved! You won't be asked again."
+  }
+  echo ""
+}
+
+# Launch the configured provider (with recursion guard)
+_gwt_launch_provider() {
+  local mode="${1:-default}"
+  local _gwt_launch_depth=${_gwt_launch_depth:-0}
+
+  if (( _gwt_launch_depth > 3 )); then
+    echo "gwt: too many provider launch attempts" >&2
+    return 1
+  fi
+
+  # Interactive selection if not configured
+  if ! _gwt_provider_configured; then
+    _gwt_select_provider || return 1
+  fi
+
+  local provider="${GWT_PROVIDER}"
+  local info
+  info=$(_gwt_get_provider "$provider")
+
+  # Check if provider exists in registry
+  if [[ -z "$info" ]]; then
+    echo "gwt: unknown provider '$provider'" >&2
+    echo "gwt: set GWT_PROVIDER or add provider to config" >&2
+    _gwt_list_providers >&2
+    return 1
+  fi
+
+  # Parse provider info: command|safe_flags|dangerous_flags|display_name
+  local cmd safe_flags dangerous_flags display_name
+  cmd="${info%%|*}"
+  info="${info#*|}"
+  safe_flags="${info%%|*}"
+  info="${info#*|}"
+  dangerous_flags="${info%%|*}"
+  display_name="${info#*|}"
+
+  # Check if command exists
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "gwt: '$cmd' not found. Install $display_name first." >&2
+    echo ""
+    echo -n "Select a different provider? [Y/n]: "
+    read -r choice
+    [[ "$choice" =~ ^[Nn]$ ]] && return 1
+    (( _gwt_launch_depth++ ))
+    _gwt_select_provider || return 1
+    _gwt_launch_provider "$mode"
+    return $?
+  fi
+
+  _gwt_debug "Launching $display_name in $mode mode"
+  echo "Opening $display_name..."
+
+  # Track session
+  _gwt_session_start "$$" "$provider"
+
+  local exit_code=0
+  case "$mode" in
+    dangerous)
+      if [[ -n "$dangerous_flags" ]]; then
+        $cmd $dangerous_flags || exit_code=$?
+      else
+        echo "Warning: $display_name doesn't support dangerous mode, using default" >&2
+        $cmd || exit_code=$?
+      fi
+      ;;
+    safe)
+      if [[ -n "$safe_flags" ]]; then
+        # Claude-specific: safe mode uses --allowedTools with tool list
+        if [[ "$provider" == "claude" ]]; then
+          $cmd $safe_flags "${GWT_ALLOWED_TOOLS[@]}" || exit_code=$?
+        else
+          $cmd $safe_flags || exit_code=$?
+        fi
+      else
+        echo "Warning: $display_name doesn't support safe mode, using default" >&2
+        $cmd || exit_code=$?
+      fi
+      ;;
+    *)
+      $cmd || exit_code=$?
+      ;;
+  esac
+
+  # Clear session
+  _gwt_session_end
+
+  # Handle failed launch
+  if [[ $exit_code -ne 0 ]]; then
+    echo ""
+    echo "gwt: $display_name exited with code $exit_code" >&2
+    echo -n "Select a different provider? [Y/n]: "
+    read -r choice
+    [[ "$choice" =~ ^[Nn]$ ]] && return $exit_code
+    (( _gwt_launch_depth++ ))
+    _gwt_select_provider || return 1
+    _gwt_launch_provider "$mode"
+    return $?
+  fi
+}

--- a/lib/session.bash
+++ b/lib/session.bash
@@ -1,0 +1,87 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Session Tracking (Bash version)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Start a session (track active AI process)
+_gwt_session_start() {
+  local pid="$1"
+  local provider="$2"
+  local wt_path
+  wt_path=$(pwd)
+
+  mkdir -p "$GWT_SESSION_DIR"
+
+  # Create session file
+  local session_file="$GWT_SESSION_DIR/$(basename "$wt_path").session"
+  cat > "$session_file" <<EOF
+PID=$pid
+PROVIDER=$provider
+PATH=$wt_path
+STARTED=$(date +%s)
+EOF
+  _gwt_debug "Session started: $session_file"
+}
+
+# End current session
+_gwt_session_end() {
+  local wt_path
+  wt_path=$(pwd)
+  local session_file="$GWT_SESSION_DIR/$(basename "$wt_path").session"
+
+  [[ -f "$session_file" ]] && rm -f "$session_file"
+  _gwt_debug "Session ended: $session_file"
+}
+
+# Check if worktree has active session
+_gwt_session_active() {
+  local wt_path="$1"
+  local session_file="$GWT_SESSION_DIR/$(basename "$wt_path").session"
+
+  [[ ! -f "$session_file" ]] && return 1
+
+  # Read PID and check if process is running
+  local pid
+  pid=$(grep "^PID=" "$session_file" 2>/dev/null | cut -d= -f2)
+  [[ -z "$pid" ]] && return 1
+
+  # Check if process is still running
+  if kill -0 "$pid" 2>/dev/null; then
+    return 0
+  else
+    # Stale session file, clean up
+    rm -f "$session_file"
+    return 1
+  fi
+}
+
+# Get session info for a worktree
+_gwt_session_info() {
+  local wt_path="$1"
+  local session_file="$GWT_SESSION_DIR/$(basename "$wt_path").session"
+
+  [[ -f "$session_file" ]] && cat "$session_file"
+}
+
+# Clean up stale sessions
+_gwt_session_cleanup() {
+  [[ ! -d "$GWT_SESSION_DIR" ]] && return 0
+
+  local count=0
+  # Bash nullglob handling
+  local old_nullglob
+  old_nullglob=$(shopt -p nullglob 2>/dev/null || echo "shopt -u nullglob")
+  shopt -s nullglob
+
+  for session_file in "$GWT_SESSION_DIR"/*.session; do
+    local pid
+    pid=$(grep "^PID=" "$session_file" 2>/dev/null | cut -d= -f2)
+    if [[ -n "$pid" ]] && ! kill -0 "$pid" 2>/dev/null; then
+      rm -f "$session_file"
+      ((count++))
+    fi
+  done
+
+  eval "$old_nullglob"
+
+  [[ $count -gt 0 ]] && _gwt_debug "Cleaned up $count stale sessions"
+}


### PR DESCRIPTION
## Summary

Adds full Bash 4.2+ support alongside existing zsh, enabling gwt to work in both shells.

## Changes

- **New files**: `gwt.bash` + 8 `lib/*.bash` modules (1,472 lines)
- **Modified**: `install.sh` - auto-detects shell, configures appropriate loader

## Architecture

```
install.sh
    |
    ├── detects $SHELL
    |
    ├── zsh ──→ source gwt.zsh ──→ lib/*.zsh
    |
    └── bash ─→ source gwt.bash ─→ lib/*.bash
```

## Key Conversions

| zsh | bash |
|-----|------|
| `${0:A:h}` | `$(dirname "${BASH_SOURCE[0]}")` |
| `typeset -gA` | `declare -gA` |
| `${(k)ARRAY}` | `${!ARRAY[@]}` |
| `*.zsh(N)` | `shopt -s nullglob` |
| `compdef` | `complete -F` |

## Requirements

- Bash 4.2+ (for `declare -gA`)
- macOS default bash is 3.x; users need `brew install bash`

## Test Plan

- [x] Syntax validation (`bash -n` on all files)
- [x] `gwt --version` / `gwt --help`
- [x] `gwt list` with color output
- [x] `gwt config` shows providers
- [x] `gwt create <branch>` creates worktree
- [x] `gwt switch -n <branch>` switches correctly
- [x] `gwt remove <branch>` cleans up
- [x] Error handling (unknown commands, missing args)
- [x] Installer detects bash/zsh correctly

Generated with [Claude Code](https://claude.ai/code)